### PR TITLE
Name stops as 'name, code' without parentheses. 

### DIFF
--- a/lib/documentStream.js
+++ b/lib/documentStream.js
@@ -33,7 +33,7 @@ function createDocumentStream(translations) {
         var name = record.stop_name;
         var stopCode;
         if (record.stop_code && record.stop_code !== '') {
-          stopCode = ' ( ' + record.stop_code + ' )';
+          stopCode = ', ' + record.stop_code;
         } else {
           stopCode = '';
         }
@@ -68,6 +68,12 @@ function createDocumentStream(translations) {
             doc.addCategory(type);
           });
         }
+        if (type === 'station') {
+          doc.setPopularity(1000000);
+        } else {
+          doc.setPopularity(10000);
+        }
+
         this.push( doc );
       }
       catch ( ex ){


### PR DESCRIPTION
Also, set high popularity for stops and very high popularity for stations to boost their presence and ranking in search results.
