### PR TITLE
csv-parse > 4.0 seems to fail randomly

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "description": "Pelias import pipeline for GTFS stops.",
   "main": "import.js",
   "dependencies": {
-    "csv-parse": "4.0.0",
+    "csv-parse": "3.2.0",
     "lodash": "^4.17.4",
     "minimist": "1.2.0",
     "through2": "3.0.0",
     "pelias-dbclient": "2.5.6",
     "pelias-logger": "1.2.1",
     "pelias-model": "5.7.1",
-    "pelias-wof-admin-lookup": "5.0.0"
+    "pelias-wof-admin-lookup": "5.0.0",
+    "joi": "^14.0.0"
   },
   "devDependencies": {
     "jshint": "2.9.4",


### PR DESCRIPTION
csv parse versions starting from v.4.0.0 fail to parse the first field of tampere gtfs's stops.txt file. Maybe because of utf8 bom at the start of the file.

