### PR TITLE
DT-4952: enrich stop and station data by public transit mode information

### DIFF
--- a/lib/documentStream.js
+++ b/lib/documentStream.js
@@ -2,21 +2,24 @@ var through = require( 'through2' );
 var peliasModel = require( 'pelias-model' );
 var logger = require( 'pelias-logger' ).get( 'pelias-GTFS' );
 
-function mapTypes(typeStr) {
+function mapTypes(types) {
+  if (types.length == 1) {
+    mode = types[0];
   // set category for single transport mode stops
-  switch(typeStr) {
-  case 'TRAM':
-    return 'tram stop';
-  case 'SUBWAY':
-    return 'subway station';
-  case 'BUS':
-    return 'bus stop';
-  case 'FERRY':
-    return 'ferry pier';
-  case 'RAIL':
-    return 'train stop';
-  case 'AIRPLANE':
-    return 'airport';
+    switch(mode) {
+    case 'TRAM':
+      return 'tram stop';
+    case 'SUBWAY':
+      return 'subway station';
+    case 'BUS':
+      return 'bus stop';
+    case 'FERRY':
+      return 'ferry pier';
+    case 'RAIL':
+      return 'train stop';
+    case 'AIRPLANE':
+      return 'airport';
+    }
   }
   return null;
 }
@@ -60,7 +63,7 @@ function buildTransportModeString(types) {
     names.push('FERRY');
   }
   if (names.length) {
-    return names.join();
+    return names;
   }
   return null;
 }

--- a/lib/documentStream.js
+++ b/lib/documentStream.js
@@ -2,20 +2,66 @@ var through = require( 'through2' );
 var peliasModel = require( 'pelias-model' );
 var logger = require( 'pelias-logger' ).get( 'pelias-GTFS' );
 
-function mapVehicleType(type) {
-  switch(type) {
-  case '0':
+function mapTypes(typeStr) {
+  // set category for single transport mode stops
+  switch(typeStr) {
+  case 'TRAM':
     return 'tram stop';
-  case '1':
+  case 'SUBWAY':
     return 'subway station';
-  case '3':
+  case 'BUS':
     return 'bus stop';
-  case '4':
+  case 'FERRY':
     return 'ferry pier';
-  case '109':
+  case 'RAIL':
     return 'train stop';
+  case 'AIRPLANE':
+    return 'airport';
+  }
+  return null;
+}
+
+function testRouteType(types, test) {
+  var hit;
+
+  Object.keys(types).forEach(type => {
+    var val = Number.parseInt(type);
+    if (!Number.isNaN(val) && test(val)) {
+      hit = true;
+    }
+  });
+  return hit;
+}
+
+function buildTransportModeString(types) {
+  if (!types) {
+    return null;
   }
 
+  var names = []; // GTFS route_type codes mapped to string
+
+  // consider original GTFS route_types and new extended ones as well
+  if (testRouteType(types, val => (val === 3 || (val >= 700 && val < 800)))) {
+    names.push('BUS');
+  }
+  if (testRouteType(types, val => (val === 0 || (val >= 900 && val < 1000)))) {
+    names.push('TRAM');
+  }
+  if (testRouteType(types, val => (val === 2 || (val >= 100 && val < 200)))) {
+    names.push('RAIL');
+  }
+  if (testRouteType(types, val => (val === 1 || (val >= 400 && val < 500)))) {
+    names.push('SUBWAY');
+  }
+  if (testRouteType(types, val => (val >= 1100 && val < 1200))) {
+    names.push('AIRPLANE');
+  }
+  if (testRouteType(types, val => (val === 4 || (val >= 1200 && val < 1300)))) {
+    names.push('FERRY');
+  }
+  if (names.length) {
+    return names.join();
+  }
   return null;
 }
 
@@ -28,7 +74,7 @@ function dedupePostfix(name, code) {
 /*
  * Create a stream of Documents from valid CSV records
  */
-function createDocumentStream(translations, prefix, activeStops) {
+function createDocumentStream(translations, prefix, activeStops, stopRouteTypes) {
 
   var badRecordCount=0;
   var unusedStopCount=0;
@@ -41,7 +87,7 @@ function createDocumentStream(translations, prefix, activeStops) {
   }
   return through.obj(
     function write( record, enc, next ){
-      if (!activeStops || activeStops[record.stop_id]) {
+      if (activeStops.notDefined || activeStops[record.stop_id]) {
 	try {
           var model_id = fullPrefix + record.stop_id;
           var name = record.stop_name;
@@ -86,10 +132,16 @@ function createDocumentStream(translations, prefix, activeStops) {
               }
             }
           }
-          var vehicleType = mapVehicleType(record.vehicle_type);
-          if (vehicleType) {
-            doc.addCategory(vehicleType);
-          }
+
+	  var transportModes = buildTransportModeString(stopRouteTypes[record.stop_id]);
+	  if (transportModes) {
+	    doc.setAddendum('GTFS', {modes: transportModes});
+            var vehicleType = mapTypes(transportModes);
+            if (vehicleType) {
+              doc.addCategory(vehicleType);
+            }
+	  }
+
           if (type === 'station') {
             doc.setPopularity(1000000);
           } else {

--- a/lib/importPipeline.js
+++ b/lib/importPipeline.js
@@ -22,24 +22,32 @@ function createImportPipeline(datadir, prefix) {
   var fileName = path.join(datadir, 'stops.txt');
   var translationFile = path.join(datadir, 'translations.txt');
   var stopTimesFile = path.join(datadir, 'stop_times.txt');
+  var tripsFile = path.join(datadir, 'trips.txt');
+  var routesFile = path.join(datadir, 'routes.txt');
 
   var csvOptions = {
     trim: true,
-    skip_empty_lines: true,
-    relax_column_count: true,
-    relax: true,
-    columns: true
+    columns: hdr => {
+      // !!! for some reason HSL GTFS stop_times.txt header contains bad chars, must trim
+      return hdr.map(key => key.trim());
+    }
   };
 
+  var routeParser = csvParse(csvOptions);
+  var tripParser = csvParse(csvOptions);
   var stopParser = csvParse(csvOptions);
   var parentStopParser = csvParse(csvOptions);
   var translationParser = csvParse(csvOptions);
   var stopTimesParser = csvParse(csvOptions);
   var translations = {};
   var activeStops = {};
+  var tripRoutes = {};
+  var routeModes = {};
+  var stopRouteTypes = {};
+  var stationStops = {};
 
   var validRecordFilterStream = ValidRecordFilterStream.create();
-  var documentStream = DocumentStream.create(translations, prefix, activeStops);
+  var documentStream = DocumentStream.create(translations, prefix, activeStops, stopRouteTypes);
   var adminLookupStream = AdminLookupStream.create();
   var finalStream = peliasDbclient({});
 
@@ -83,12 +91,26 @@ function createImportPipeline(datadir, prefix) {
     }
   };
 
-  // mark stops through which trips travel active
+  // mark stops through which trips travel active, and extract route types (=transport modes in OTP terms)
   var activeStopCollector = through.obj(function (record, enc, next) {
     activeStops[record.stop_id] = true;
-      next();
+    if(!stopRouteTypes[record.stop_id]) {
+      stopRouteTypes[record.stop_id] = {};
+    }
+    stopRouteTypes[record.stop_id][routeModes[tripRoutes[record.trip_id]]] = true;
+    next();
   }, function (done) {
     logger.info('Stop references analyzed');
+    // collect station route types from child stops
+    Object.keys(stationStops).forEach(station => {
+      const stops = stationStops[station];
+      stops.forEach(stop => {
+	stopRouteTypes[station] = {
+	  ...stopRouteTypes[station],
+	  ...stopRouteTypes[stop]
+	};
+      });
+    });
     importWithTranslations();
     done();
   });
@@ -96,28 +118,60 @@ function createImportPipeline(datadir, prefix) {
   // mark stations which have child stops active
   var parentStopCollector = through.obj(function (record, enc, next) {
     if (record.parent_station) {
-      activeStops[record.parent_station] = true;
+      const parent_id = record.parent_station;
+      activeStops[parent_id] = true;
+      if(!stationStops[parent_id]){
+	stationStops[parent_id] = [];
+      }
+      stationStops[parent_id].push(record.stop_id);
     }
     next();
   }, function (done) {
     logger.info('Parent station references analyzed');
-    if (fs.existsSync(stopTimesFile)) {
-      fs.createReadStream(stopTimesFile)
-	.pipe(stopTimesParser)
-	.pipe(activeStopCollector);
-    } else {
-      importWithTranslations();
-    }
+    fs.createReadStream(stopTimesFile)
+      .pipe(stopTimesParser)
+      .pipe(activeStopCollector);
+    done();
+  });
+
+  // extract routes by trip map
+  var tripCollector = through.obj(function (record, enc, next) {
+    tripRoutes[record.trip_id] = record.route_id;
+    next();
+  }, function (done) {
+    logger.info('Trips analyzed');
+
+    fs.createReadStream(fileName)
+      .pipe(parentStopParser)
+      .pipe(parentStopCollector);
+    done();
+  });
+
+  // extract route modes
+  var routeCollector = through.obj(function (record, enc, next) {
+    routeModes[record.route_id] = record.route_type;
+    next();
+  }, function (done) {
+    logger.info('Routes analyzed');
+    fs.createReadStream(tripsFile)
+      .pipe(tripParser)
+      .pipe(tripCollector);
     done();
   });
 
   logger.info('Waiting for WOF setup');
   setTimeout(function() {
     logger.info('Start import');
-    fs.createReadStream(fileName)
-      .pipe(parentStopParser)
-      .pipe(parentStopCollector);
-  }, 6000);
+    if (fs.existsSync(routesFile) && fs.existsSync(tripsFile) && fs.existsSync(stopTimesFile)) {
+      // enrich data by scanning active stops and stations and their transport modes
+      fs.createReadStream(routesFile)
+	.pipe(routeParser)
+	.pipe(routeCollector);
+    } else {
+      activeStops.notDefined = true;
+      importWithTranslations();
+    }
+  }, 4000);
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Pelias import pipeline for GTFS stops.",
   "main": "import.js",
   "dependencies": {
-    "csv-parse": "4.16.0",
+    "csv-parse": "4.16.3",
     "lodash": "^4.17.4",
     "minimist": "1.2.0",
     "through2": "4.0.2",
@@ -13,14 +13,6 @@
     "pelias-logger": "1.2.1",
     "pelias-model": "7.1.0",
     "joi": "^14.0.0"
-  },
-  "devDependencies": {
-    "jshint": "2.9.4",
-    "precommit-hook": "3.0.0"
-  },
-  "scripts": {
-    "lint": "jshint .",
-    "validate": "npm ls"
   },
   "repository": {
     "type": "git",
@@ -35,9 +27,5 @@
   "bugs": {
     "url": "https://github.com/hsldevcom/pelias-gtfs/issues"
   },
-  "homepage": "https://github.com/hsldevcom/pelias-gtfs",
-  "pre-commit": [
-    "lint",
-    "test"
-  ]
+  "homepage": "https://github.com/hsldevcom/pelias-gtfs"
 }


### PR DESCRIPTION
Stop and station items now have new attributes as follows:

```
{

 addendum: {
     GTFS: {
         modes: ["BUS,TRAM"]
     }
}

```
Mode array can include strings BUS, TRAM, SUBWAY, RAIL, FERRY, AIRPLANE .

Note that due to source data limitations/errors, addendum may be missing.
